### PR TITLE
Binary protocol over bluetooth

### DIFF
--- a/apps/dexdrip/dexdrip.c
+++ b/apps/dexdrip/dexdrip.c
@@ -243,7 +243,6 @@ void send_dexdrip_packet(uint8 packet_type, uint8 packet_len, uint8 XDATA *paylo
     pkt.packet_type = packet_type;
     pkt.len = packet_len;
     pkt.payload = payload;
-    pkt.version = DATA_PACKET_VERSION;
     uart1_send_dexdrip_packet(&pkt);
 }
 
@@ -254,7 +253,7 @@ void send_data_packet(Dexcom_packet* pPkt) {
     data.raw = htonl(dex_num_decoder(pPkt->raw));
     data.dexdrip_battery = htons(adcConvertToMillivolts(adcRead(0)));
     data.dexcom_battery = pPkt->battery;
-
+    data.version = DATA_PACKET_VERSION;
     send_dexdrip_packet(DATA_PACKET, sizeof(dexdrip_data_packet_t), (uint8 XDATA*)&data);
 }
 

--- a/apps/dexdrip/dexdrip.c
+++ b/apps/dexdrip/dexdrip.c
@@ -243,6 +243,7 @@ void send_dexdrip_packet(uint8 packet_type, uint8 packet_len, uint8 XDATA *paylo
     pkt.packet_type = packet_type;
     pkt.len = packet_len;
     pkt.payload = payload;
+    pkt.version = DATA_PACKET_VERSION;
     uart1_send_dexdrip_packet(&pkt);
 }
 

--- a/libraries/include/dexdrip_packet.h
+++ b/libraries/include/dexdrip_packet.h
@@ -5,11 +5,16 @@ enum dexdrip_packet_type {
     DATA_PACKET = 1,
 };
 
+/*
+ * Keep this alligned and multiple of 4
+ */
+#define DATA_PACKET_VERSION 1
+
 typedef struct dexdrip_data_packet {
+    uint8 version;
+    uint8 dexcom_battery;
+    uint16 dexdrip_battery;
     uint32 raw;
-    int16  dexdrip_battery;
-    uint8  dexcom_battery;
-    uint8  padding[1];
 } dexdrip_data_packet_t;
 
 typedef struct dexdrip_binary_packet {

--- a/libraries/include/dexdrip_packet.h
+++ b/libraries/include/dexdrip_packet.h
@@ -1,0 +1,21 @@
+#ifndef __DEXDRIP_PACKET_H__
+#define __DEXDRIP_PACKET_H__
+
+enum dexdrip_packet_type {
+    DATA_PACKET = 1,
+};
+
+typedef struct dexdrip_data_packet {
+    uint32 raw;
+    int16  dexdrip_battery;
+    uint8  dexcom_battery;
+    uint8  padding[1];
+} dexdrip_data_packet_t;
+
+typedef struct dexdrip_binary_packet {
+    uint8 packet_type;
+    uint8 len; /* payload length */
+    uint8 XDATA *payload;
+} dexdrip_binary_packet_t;
+
+#endif

--- a/libraries/include/inet.h
+++ b/libraries/include/inet.h
@@ -1,0 +1,26 @@
+#ifndef __INET_H__
+#define __INET_H__
+
+/* Wixel is little endian */
+unsigned short htons(unsigned short n)
+{
+    return ((n & 0xFF) << 8) | ((n & 0xFF00) >> 8);
+}
+
+unsigned short ntohs(unsigned short n)
+{
+    return htons(n);
+}
+
+unsigned long htonl(unsigned long n)
+{
+    return ((n & 0xFF) << 24) | ((n & 0xFF00) << 8) | 
+        ((n & 0xFF0000) >> 8) | ((n & 0xFF000000) >> 24);
+}
+
+unsigned long ntohl(unsigned long n)
+{
+    return htonl(n);
+}
+
+#endif


### PR DESCRIPTION
Change data exachange over bluetooth to a binary format.

Advantages:
1. data can easily be decoded;
2. more robust to error and is not taking just parts of the packets;
3. can be easily extended:
- for example I want to add next getMs and a packet id to the packets; the bluetooth chip is buffering packets if here is no connection and packets can be get with read.
