### PR TITLE
Added \n character to print_packet

### DIFF
--- a/apps/dexdrip/dexdrip.c
+++ b/apps/dexdrip/dexdrip.c
@@ -227,7 +227,7 @@ uint32 getSrcValue(char srcVal) {
 }
 void print_packet(Dexcom_packet* pPkt) {
     uartEnable();
-    printf("%lu %hhu %d", dex_num_decoder(pPkt->raw), pPkt->battery, adcConvertToMillivolts(adcRead(0)));
+    printf("%lu %hhu %d\n", dex_num_decoder(pPkt->raw), pPkt->battery, adcConvertToMillivolts(adcRead(0)));
     uartDisable();
 }
 


### PR DESCRIPTION
Print_packet is very difficult to frame for serial communications. Adding a termination character like \n will help users to know when the packet has ended and close the comm channel.
