### PR TITLE
Fixes compile error under OSX

### DIFF
--- a/libraries/src/usb/usb.c
+++ b/libraries/src/usb/usb.c
@@ -8,7 +8,7 @@
 
 extern uint8 CODE usbConfigurationDescriptor[];
 
-void usbStandardDeviceRequestHandler();
+static void usbStandardDeviceRequestHandler();
 
 #define CONTROL_TRANSFER_STATE_NONE  0
 #define CONTROL_TRANSFER_STATE_WRITE 1


### PR DESCRIPTION
Reference: https://github.com/pololu/wixel-sdk/pull/8

This allows the wixel-xDrip code to compile under an OSX environment.
